### PR TITLE
Skip regexpengine option on vim <= 7.3

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -30,7 +30,9 @@ set ruler
 " regexp engine does NOT play nice with Ruby lang syntax highlighting.
 " Switching to the older non NFA regexp engine drastically increases
 " performance.
-set regexpengine=1
+if version >= 704
+  set regexpengine=1
+endif
 
 " keep buffers opened in background until :q or :q!
 set hidden

--- a/vimrc
+++ b/vimrc
@@ -30,7 +30,7 @@ set ruler
 " regexp engine does NOT play nice with Ruby lang syntax highlighting.
 " Switching to the older non NFA regexp engine drastically increases
 " performance.
-if version >= 704
+if exists('+regexpengine')
   set regexpengine=1
 endif
 


### PR DESCRIPTION
`regexpengine` was added in 7.4 and shows a warning on every startup
in earlier versions. Wrapping it in a version check to suppress that.